### PR TITLE
Always return custom user column value

### DIFF
--- a/jigsaw.php
+++ b/jigsaw.php
@@ -160,6 +160,8 @@ class Jigsaw {
 				ob_start();
 				$callback( $uid );
 				return ob_get_clean();
+			} else {
+				return $val;
 			}
 		}, 10, 3);
 	}


### PR DESCRIPTION
Be sure to always return $val in the manage_users_custom_column callback so we don’t accidentally overwrite other plugins’ columns.